### PR TITLE
Add Account Type Support, kc Ranks, and new Wildy Bosses

### DIFF
--- a/src/osrs/__init__.py
+++ b/src/osrs/__init__.py
@@ -1,3 +1,4 @@
 import osrs.ge
 import osrs.hiscores
 import osrs.itemaliases
+import osrs.accounttype

--- a/src/osrs/accounttype.py
+++ b/src/osrs/accounttype.py
@@ -1,0 +1,99 @@
+"""
+AccountType enum and utils to handle conversions.
+"""
+
+import enum
+
+class AccountType(enum.Enum):
+	ERROR = -1
+	REGULAR = 0
+	IRONMAN = 1
+	HARDCORE_IRONMAN = 2
+	ULTIMATE_IRONMAN = 3
+	SKILLER = 4
+	PURE = 5
+
+def readable_account_type(account_type: AccountType) -> str:
+	"""Prettifies the AccountType enum name.
+
+	e.g. HARDCORE_IRONMAN -> Hardcore Ironman
+	"""
+	return ' '.join(account_type.name.split('_')).title()
+
+account_type_aliases = {
+	"": AccountType.REGULAR,
+	"regular": AccountType.REGULAR,
+	"standard": AccountType.REGULAR,
+	"normie": AccountType.REGULAR,
+	"ge": AccountType.REGULAR,
+	"secretlysupportedbybots": AccountType.REGULAR,
+	"vorkathfarmer": AccountType.REGULAR,
+	"goldfarmer": AccountType.REGULAR,
+	"pethunter": AccountType.REGULAR,
+	"unrestricted": AccountType.REGULAR,
+	"trader": AccountType.REGULAR,
+	"traitor": AccountType.REGULAR,
+
+	"iron": AccountType.IRONMAN,
+	"fe": AccountType.IRONMAN,
+	"ironman": AccountType.IRONMAN,
+	"ironmeme": AccountType.IRONMAN,
+	"ironwoman": AccountType.IRONMAN,
+	"btw": AccountType.IRONMAN,
+	"im": AccountType.IRONMAN,
+	"grayhelm": AccountType.IRONMAN,
+	"greyhelm": AccountType.IRONMAN,
+
+	"hardcoreironman": AccountType.HARDCORE_IRONMAN,
+	"hardcore_ironman": AccountType.HARDCORE_IRONMAN,
+	"hardcoreiron": AccountType.HARDCORE_IRONMAN,
+	"hardcoreironwoman": AccountType.HARDCORE_IRONMAN,
+	"hcim": AccountType.HARDCORE_IRONMAN,
+	"hc": AccountType.HARDCORE_IRONMAN,
+	"hcbtw": AccountType.HARDCORE_IRONMAN,
+	"coward": AccountType.HARDCORE_IRONMAN,
+	"deathless": AccountType.HARDCORE_IRONMAN,
+	"redhelm": AccountType.HARDCORE_IRONMAN,
+
+	"ultimateironman": AccountType.ULTIMATE_IRONMAN,
+	"ultimate_ironman": AccountType.ULTIMATE_IRONMAN,
+	"uim": AccountType.ULTIMATE_IRONMAN,
+	"bankless": AccountType.ULTIMATE_IRONMAN,
+	"nobank": AccountType.ULTIMATE_IRONMAN,
+	"masochist": AccountType.ULTIMATE_IRONMAN,
+	"ihavetoomuchtime": AccountType.ULTIMATE_IRONMAN,
+	"donttrustbanks": AccountType.ULTIMATE_IRONMAN,
+	"badcredit": AccountType.ULTIMATE_IRONMAN,
+	"pohfanatic": AccountType.ULTIMATE_IRONMAN,
+	"valuablesack": AccountType.ULTIMATE_IRONMAN,
+
+	"skiller": AccountType.SKILLER,
+	"onlycans": AccountType.SKILLER,
+	"skill": AccountType.SKILLER,
+	"scaredofcombat": AccountType.SKILLER,
+	"peacekeeper": AccountType.SKILLER,
+	"nopvm": AccountType.SKILLER,
+	"bownoarrow": AccountType.SKILLER,
+
+	"pure": AccountType.PURE,
+	"1def": AccountType.PURE,
+	"pker": AccountType.PURE,
+	"ieatalldamage": AccountType.PURE,
+	"minmax": AccountType.PURE,
+}
+
+def str_to_account_type(account_type_str: str) -> AccountType:
+	"""Convert common names to AccountType enum.
+
+	Note that capitalization and spaces are unused. e.g. All of the following result in HARDCORE_IRONMAN
+	* Hardcore Ironman
+	* Hard Core Iron Man
+	* hard coreiron man
+	* hardcoreironman
+
+	If it doesn't exist in the known aliases, return AccountType.ERROR.
+	"""
+	sanitized_str = account_type_str.replace(' ', '').lower()
+	if sanitized_str in account_type_aliases:
+		return account_type_aliases[sanitized_str]
+	return AccountType.ERROR

--- a/src/rememberaccount.py
+++ b/src/rememberaccount.py
@@ -41,7 +41,7 @@ def get_rs_username_and_type(tg_user_id, session=None) -> tuple[str, AccountType
 	if session == None:
 		session = database.dbsession()
 	ra = get_remembered_account(tg_user_id, session)
-	return ra.rs_username, ra.rs_account_type if ra else (None, None)
+	return (ra.rs_username, ra.rs_account_type) if ra else (None, None)
 
 invalid_rsn_chars = re.compile('[^\w _]')
 def is_valid_rsn(rs_username):

--- a/src/rememberaccount.py
+++ b/src/rememberaccount.py
@@ -1,19 +1,23 @@
 import re
 
-from sqlalchemy import Column, BigInteger, String
+from sqlalchemy import Column, BigInteger, String, Enum
 from telegram.ext import CommandHandler
 
 import database
+import enum
+from osrs.accounttype import AccountType, str_to_account_type, readable_account_type
 
 class RememberedAccount(database.Base):
 	__tablename__ = 'rememberedaccounts'
 
 	tg_user_id = Column(BigInteger, primary_key=True)
 	rs_username = Column(String(32))
+	rs_account_type = Column(Enum(AccountType))
 
-	def __init__(self, tg_user_id, rs_username):
+	def __init__(self, tg_user_id, rs_username: str, rs_account_type: AccountType):
 		self.tg_user_id = tg_user_id
 		self.rs_username = rs_username
+		self.rs_account_type = rs_account_type
 
 def get_remembered_account(tg_user_id, session=None):
 	if session == None:
@@ -29,13 +33,49 @@ def get_rs_username(tg_user_id, session=None):
 	ra = get_remembered_account(tg_user_id, session)
 	return ra.rs_username if ra else None
 
+def get_rs_username_and_type(tg_user_id, session=None) -> tuple[str, AccountType]:
+	"""Returns a tuple containing the remembered username and account type.
+
+	If unavailable, this results in (None, None)
+	"""
+	if session == None:
+		session = database.dbsession()
+	ra = get_remembered_account(tg_user_id, session)
+	return ra.rs_username, ra.rs_account_type if ra else (None, None)
+
 invalid_rsn_chars = re.compile('[^\w _]')
 def is_valid_rsn(rs_username):
 	return re.search(invalid_rsn_chars, rs_username) == None
 
 async def cmd_remember(update, context):
-	args = context.args
-	rs_username = (' '.join(args))[:30]
+	"""Store the incoming player username from context into DB.
+
+	context.arg will be assumed to have the form:
+
+	rs username[, account_type]
+
+	Where [, account_type] is optional.
+	The username cannot be longer than 12 characters and the account type must
+	be any cased version of account_type_aliases keys.
+	e.g. Iron Hyger, Ironman
+	"""
+	# Reform the args from space separated to comma separated
+	args = ' '.join(context.args).split(',')
+	if len(args) > 2:
+		await update.message.reply_text('You\'ve given me too many things to work with.')
+		return
+
+    # Trim everything after the first 12 characters as OSRS names cannot
+    # exceed 12 characters.
+	rs_username = args[0][:12] if args else ''
+
+	rs_account_type = AccountType.REGULAR
+	if len(args) > 1:
+		rs_account_type = str_to_account_type(args[1])
+		if rs_account_type == AccountType.ERROR:
+			await update.message.reply_text('You\'ve given me an invalid account type: ' + args[1])
+			return
+
 	tg_user_id = update.message.from_user.id
 
 	session = database.dbsession()
@@ -48,15 +88,16 @@ async def cmd_remember(update, context):
 
 		ra = get_remembered_account(tg_user_id, session=session)
 		if ra == None:
-			ra = RememberedAccount(tg_user_id, rs_username)
+			ra = RememberedAccount(tg_user_id, rs_username, rs_account_type)
 		else:
 			ra.rs_username = rs_username
+			ra.rs_account_type = rs_account_type
 		session.add(ra)
 		session.commit()
 		await update.message.reply_text(
 			'OK, I will remember your Old School RuneScape username (RSN): ' + \
-			'*{}*\n\n'.format(
-				rs_username
+			'*{}* (*{}* account)\n\n'.format(
+				rs_username, readable_account_type(rs_account_type)
 			) + \
 			'I\'ll assume you want to use this name for commands like /skills from now on. ' + \
 			'When you use /kc now, give me a hiscores label instead of an RSN. ' + \
@@ -65,12 +106,12 @@ async def cmd_remember(update, context):
 		)
 
 	else:
-		rs_username = get_rs_username(tg_user_id)
+		rs_username, rs_account_type = get_rs_username_and_type(tg_user_id)
 		if rs_username:
 			await update.message.reply_text(
 				'I am remembering this Old School RuneScape account username (RSN) for you: ' + \
-				'*{}*\n\n'.format(
-					rs_username
+				'*{}* (*{}* account)\n\n'.format(
+					rs_username, readable_account_type(rs_account_type)
 				) + \
 				'You can tell me to /forget this, or use /remember again to recall or change it.',
 				parse_mode='Markdown'


### PR DESCRIPTION
Updates new Wildy bosses (Artio, Calvar'ion, and Spindel)
Adds AccountType along with the ability to use it via /kc and /remember:
 * /kc Iron Yeen, Kree'Arra, Ironman
 * /remember Iron Yeen, Ironman

Updates Activities and Boss KC to display Ranks as well:
/kc Iron Yeen, Kree'Arra, Ironman
Iron Yeen (Ironman): Kree'Arra: 187  #12982